### PR TITLE
adjusting login success logic

### DIFF
--- a/src/client/components/view/LoginView.js
+++ b/src/client/components/view/LoginView.js
@@ -15,7 +15,10 @@ const LoginView = ({ navigation }) => {
   const handleLogin = (loginMethod) => {
     setIncorrectCredentials(false);
     if (username && password) {
-      navigation.navigate("Overview", { name: username });
+      navigation.reset({
+        index: 0,
+        routes: [{ name: "Overview", params: { name: username } }],
+      });
     } else {
       setIncorrectCredentials(true);
     }


### PR DESCRIPTION
users were previously able to go back from the home page to the login view, didn't want that so I adjusted the logic to reset the navigation stack when they login so the OverView page is the "home base" 