### PR TITLE
chore: do not recompile tex files on main

### DIFF
--- a/.github/workflows/compile-tex.yml
+++ b/.github/workflows/compile-tex.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - '**'
+    branches-ignore:
+      - 'main'
     paths:
       - 'docs/**/*.tex'
 


### PR DESCRIPTION
it violates main branch protection rules; we should just generate the PDFs as part of a PR