### PR TITLE
feat: add in onboarding page

### DIFF
--- a/src/client/App.js
+++ b/src/client/App.js
@@ -27,10 +27,10 @@ export default function App() {
     <TamaguiProvider config={config}>
       <NavigationContainer>
         <Stack.Navigator>
-          <Stack.Screen name="Onboarding" component={OnboardingView} />
           <Stack.Screen name="Login" component={LoginView} />
           <Stack.Screen name="ResetPassword" component={ResetPasswordView} />
           <Stack.Screen name="Register" component={RegisterView} />
+          <Stack.Screen name="Onboarding" component={OnboardingView} />
           <Stack.Screen name="Overview" component={OverView} />
           <Stack.Screen name="MyIncome" component={MyIncome} />
           <Stack.Screen name="NewIncome" component={NewIncomePage} />

--- a/src/client/App.js
+++ b/src/client/App.js
@@ -11,6 +11,7 @@ import RegisterView from "./components/view/RegisterView";
 import ResetPasswordView from "./components/view/ResetPasswordView";
 import OverView from "./components/view/OverView";
 import AddExpenseView from "./components/view/AddExpenseView";
+import OnboardingView from "./components/view/OnboardingView";
 import { useFonts } from "expo-font";
 import { TamaguiProvider } from "tamagui";
 import config from "./tamagui.config";
@@ -26,6 +27,7 @@ export default function App() {
     <TamaguiProvider config={config}>
       <NavigationContainer>
         <Stack.Navigator>
+          <Stack.Screen name="Onboarding" component={OnboardingView} />
           <Stack.Screen name="Login" component={LoginView} />
           <Stack.Screen name="ResetPassword" component={ResetPasswordView} />
           <Stack.Screen name="Register" component={RegisterView} />

--- a/src/client/assets/icons/CheckMark.js
+++ b/src/client/assets/icons/CheckMark.js
@@ -1,0 +1,22 @@
+import React from "react";
+import Svg, { Path } from "react-native-svg";
+
+const CheckMark = ({ size = 50, style }) => (
+  <Svg
+    style={style}
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <Path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M9.9647 14.9617L17.4693 7.44735L18.5307 8.50732L9.96538 17.0837L5.46967 12.588L6.53033 11.5273L9.9647 14.9617Z"
+      fill="#1F2328"
+    />
+  </Svg>
+);
+
+export default CheckMark;

--- a/src/client/components/view/OnboardingView.tsx
+++ b/src/client/components/view/OnboardingView.tsx
@@ -1,13 +1,12 @@
-import { StyleSheet, Text, TextInput, View } from "react-native";
+import { StyleSheet, Text, TextInput, View, Pressable } from "react-native";
 import BackArrow from "../../assets/icons/BackArrow";
 import { DEFAULT_COLOURS } from "../../styles/commonStyles";
 import HorizontalRule from "../common/HorizontalRule";
 import { Button, Checkbox, Label } from "tamagui";
 import CheckMark from "../../assets/icons/CheckMark";
 import { useState } from "react";
-import { CheckboxStyledContext } from "@tamagui/checkbox";
 
-const OnboardingView = () => {
+const OnboardingView = ({ navigation, route }) => {
   const [firstName, setFirstName] = useState("");
   const [middleName, setMiddleName] = useState("");
   const [lastName, setLastName] = useState("");
@@ -16,15 +15,37 @@ const OnboardingView = () => {
   const [occupation, setOccupation] = useState("");
   const [keepLogin, setKeepLogin] = useState(false);
 
+  const returnHandler = () => {
+    navigation.navigate("Register", {
+      /* We can return the email back to the previous page and autofill in the text entry again
+		if we want or smth. */
+      email: route.params?.email,
+    });
+  };
+
   const createAccountHandler = () => {
-    // add user to db
-    console.log(keepLogin);
+    // TODO: add user to db
+
+    // Redirect user to overview page if user account is successful, else show error or smth idk
+    navigation.reset({
+      index: 0,
+      routes: [
+        {
+          name: "Overview",
+          params: {
+            name: `${firstName} ${lastName}`,
+          },
+        },
+      ],
+    });
   };
 
   return (
     <View style={styles.onboardingBox}>
       <View style={styles.headerBox}>
-        <BackArrow size={20} style={styles.backArrow} />
+        <Pressable onPress={returnHandler} style={styles.backArrow}>
+          <BackArrow size={20} />
+        </Pressable>
         <Text style={styles.headerText}>Please Enter Your Information</Text>
       </View>
       <View style={styles.nameBox}>

--- a/src/client/components/view/OnboardingView.tsx
+++ b/src/client/components/view/OnboardingView.tsx
@@ -1,0 +1,31 @@
+import { StyleSheet, Text, View } from "react-native";
+
+const OnboardingView = () => {
+  return (
+    <View style={styles.onboardingBox}>
+      <View style={styles.headerBox}>
+        <Text style={styles.headerText}>Please Enter Your Information</Text>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  onboardingBox: {
+    height: "100%",
+    backgroundColor: "white",
+  },
+  headerBox: {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    height: "5%",
+    margin: 12,
+  },
+  headerText: {
+    fontSize: 20,
+    fontWeight: "700",
+  },
+});
+
+export default OnboardingView;

--- a/src/client/components/view/OnboardingView.tsx
+++ b/src/client/components/view/OnboardingView.tsx
@@ -1,11 +1,75 @@
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, TextInput, View } from "react-native";
+import BackArrow from "../../assets/icons/BackArrow";
+import { DEFAULT_COLOURS } from "../../styles/commonStyles";
+import HorizontalRule from "../common/HorizontalRule";
+import { Button, Checkbox, Label } from "tamagui";
+import CheckMark from "../../assets/icons/CheckMark";
 
 const OnboardingView = () => {
   return (
     <View style={styles.onboardingBox}>
       <View style={styles.headerBox}>
+        <BackArrow size={20} style={styles.backArrow} />
         <Text style={styles.headerText}>Please Enter Your Information</Text>
       </View>
+      <View style={styles.nameBox}>
+        <TextInput
+          placeholder="First Name"
+          style={styles.textInput}
+          placeholderTextColor={DEFAULT_COLOURS.secondary}
+        />
+        <TextInput
+          placeholder="Middle Name"
+          style={styles.textInput}
+          placeholderTextColor={DEFAULT_COLOURS.secondary}
+        />
+        <TextInput
+          placeholder="Last Name"
+          style={styles.textInput}
+          placeholderTextColor={DEFAULT_COLOURS.secondary}
+        />
+      </View>
+
+      <HorizontalRule />
+
+      {/* Replace these with the corresponding dropdowns later */}
+      <View style={styles.demographicDataBox}>
+        <TextInput
+          placeholder="Sex/Gender"
+          style={styles.textInput}
+          placeholderTextColor={DEFAULT_COLOURS.secondary}
+        />
+        <TextInput
+          placeholder="Date of Birth"
+          style={styles.textInput}
+          placeholderTextColor={DEFAULT_COLOURS.secondary}
+        />
+        <TextInput
+          placeholder="Occupation/Industry"
+          style={styles.textInput}
+          placeholderTextColor={DEFAULT_COLOURS.secondary}
+        />
+      </View>
+
+      <View style={styles.checkBox}>
+        <Checkbox marginRight={12} id="check">
+          <Checkbox.Indicator>
+            <CheckMark size={20} />
+          </Checkbox.Indicator>
+        </Checkbox>
+        <Label size={10} htmlFor="check">
+          Enable Notifications
+        </Label>
+      </View>
+
+      <Button
+        backgroundColor={DEFAULT_COLOURS.primary}
+        width={"60%"}
+        marginTop={20}
+        marginHorizontal={"auto"}
+      >
+        <Text>Create Account</Text>
+      </Button>
     </View>
   );
 };
@@ -14,6 +78,7 @@ const styles = StyleSheet.create({
   onboardingBox: {
     height: "100%",
     backgroundColor: "white",
+    display: "flex",
   },
   headerBox: {
     display: "flex",
@@ -21,10 +86,45 @@ const styles = StyleSheet.create({
     alignItems: "center",
     height: "5%",
     margin: 12,
+    position: "relative",
   },
   headerText: {
-    fontSize: 20,
+    fontSize: 18,
     fontWeight: "700",
+  },
+  backArrow: {
+    position: "absolute",
+    left: 12,
+  },
+  textInput: {
+    width: "60%",
+    backgroundColor: "#EDEDED",
+    height: 40,
+    padding: 14,
+    borderRadius: 10,
+  },
+  nameBox: {
+    display: "flex",
+    alignItems: "center",
+    rowGap: 16,
+    marginBottom: 12,
+  },
+  hRule: {
+    margin: 12,
+  },
+  demographicDataBox: {
+    display: "flex",
+    alignItems: "center",
+    rowGap: 16,
+    marginVertical: 12,
+  },
+  checkBox: {
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    alignItems: "center",
+    width: "60%",
+    alignSelf: "center",
   },
 });
 

--- a/src/client/components/view/OnboardingView.tsx
+++ b/src/client/components/view/OnboardingView.tsx
@@ -4,8 +4,23 @@ import { DEFAULT_COLOURS } from "../../styles/commonStyles";
 import HorizontalRule from "../common/HorizontalRule";
 import { Button, Checkbox, Label } from "tamagui";
 import CheckMark from "../../assets/icons/CheckMark";
+import { useState } from "react";
+import { CheckboxStyledContext } from "@tamagui/checkbox";
 
 const OnboardingView = () => {
+  const [firstName, setFirstName] = useState("");
+  const [middleName, setMiddleName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [sex, setSex] = useState("");
+  const [dob, setDob] = useState("");
+  const [occupation, setOccupation] = useState("");
+  const [keepLogin, setKeepLogin] = useState(false);
+
+  const createAccountHandler = () => {
+    // add user to db
+    console.log(keepLogin);
+  };
+
   return (
     <View style={styles.onboardingBox}>
       <View style={styles.headerBox}>
@@ -17,16 +32,22 @@ const OnboardingView = () => {
           placeholder="First Name"
           style={styles.textInput}
           placeholderTextColor={DEFAULT_COLOURS.secondary}
+          value={firstName}
+          onChangeText={setFirstName}
         />
         <TextInput
           placeholder="Middle Name"
           style={styles.textInput}
           placeholderTextColor={DEFAULT_COLOURS.secondary}
+          value={middleName}
+          onChangeText={setMiddleName}
         />
         <TextInput
           placeholder="Last Name"
           style={styles.textInput}
           placeholderTextColor={DEFAULT_COLOURS.secondary}
+          value={lastName}
+          onChangeText={setLastName}
         />
       </View>
 
@@ -38,27 +59,38 @@ const OnboardingView = () => {
           placeholder="Sex/Gender"
           style={styles.textInput}
           placeholderTextColor={DEFAULT_COLOURS.secondary}
+          value={sex}
+          onChangeText={setSex}
         />
         <TextInput
           placeholder="Date of Birth"
           style={styles.textInput}
           placeholderTextColor={DEFAULT_COLOURS.secondary}
+          value={dob}
+          onChangeText={setDob}
         />
         <TextInput
           placeholder="Occupation/Industry"
           style={styles.textInput}
           placeholderTextColor={DEFAULT_COLOURS.secondary}
+          value={occupation}
+          onChangeText={setOccupation}
         />
       </View>
 
       <View style={styles.checkBox}>
-        <Checkbox marginRight={12} id="check">
+        <Checkbox
+          marginRight={12}
+          id="check"
+          checked={keepLogin}
+          onCheckedChange={() => setKeepLogin(!keepLogin)}
+        >
           <Checkbox.Indicator>
             <CheckMark size={20} />
           </Checkbox.Indicator>
         </Checkbox>
         <Label size={10} htmlFor="check">
-          Enable Notifications
+          Stay signed in on this device
         </Label>
       </View>
 
@@ -67,6 +99,7 @@ const OnboardingView = () => {
         width={"60%"}
         marginTop={20}
         marginHorizontal={"auto"}
+        onPress={createAccountHandler}
       >
         <Text>Create Account</Text>
       </Button>

--- a/src/client/components/view/RegisterView.tsx
+++ b/src/client/components/view/RegisterView.tsx
@@ -8,8 +8,10 @@ import {
   validatePassword,
 } from "firebase/auth";
 
-const RegisterView = ({ navigation }) => {
-  const [email, setEmail] = useState("");
+const RegisterView = ({ navigation, route }) => {
+  const [email, setEmail] = useState(
+    route.params?.email ? route.params?.email : "",
+  );
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
@@ -41,9 +43,9 @@ const RegisterView = ({ navigation }) => {
         /* Probably link a name attribute eventually */
         routes: [
           {
-            name: "Overview",
+            name: "Onboarding",
             params: {
-              name: user.user.displayName ? "User 123" : user.user.displayName,
+              email: email,
             },
           },
         ],

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -14,6 +14,7 @@
         "@react-native-picker/picker": "2.9.0",
         "@react-navigation/native": "^7.0.3",
         "@react-navigation/stack": "^7.0.5",
+        "@tamagui/checkbox": "^1.122.6",
         "@tamagui/config": "^1.117.1",
         "@tamagui/core": "^1.117.1",
         "@tamagui/font-inter": "^1.117.1",
@@ -5404,46 +5405,882 @@
       }
     },
     "node_modules/@tamagui/checkbox": {
-      "version": "1.121.12",
-      "resolved": "https://registry.npmjs.org/@tamagui/checkbox/-/checkbox-1.121.12.tgz",
-      "integrity": "sha512-cySEIQ399GApeDP408+rXWuHEgiKshLLgyqWJaFibbGSzgnAAPPa2RSavA00B1kSgXwEHupxVgkhkBQ4ph/P4Q==",
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/checkbox/-/checkbox-1.122.6.tgz",
+      "integrity": "sha512-YN1Iiu8vB1jlh6Rfd1Yv1MCAf85OPjTh6EyqAWJlwI1dyuHTcqhU6ni+VXsjY82TRNahVK0VzRzQO7C29fNDhQ==",
       "dependencies": {
-        "@tamagui/checkbox-headless": "1.121.12",
-        "@tamagui/compose-refs": "1.121.12",
-        "@tamagui/constants": "1.121.12",
-        "@tamagui/core": "1.121.12",
-        "@tamagui/create-context": "1.121.12",
-        "@tamagui/focusable": "1.121.12",
-        "@tamagui/font-size": "1.121.12",
-        "@tamagui/get-token": "1.121.12",
-        "@tamagui/helpers": "1.121.12",
-        "@tamagui/helpers-tamagui": "1.121.12",
-        "@tamagui/label": "1.121.12",
-        "@tamagui/stacks": "1.121.12",
-        "@tamagui/use-controllable-state": "1.121.12",
-        "@tamagui/use-previous": "1.121.12"
+        "@tamagui/checkbox-headless": "1.122.6",
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/core": "1.122.6",
+        "@tamagui/create-context": "1.122.6",
+        "@tamagui/focusable": "1.122.6",
+        "@tamagui/font-size": "1.122.6",
+        "@tamagui/get-token": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/helpers-tamagui": "1.122.6",
+        "@tamagui/label": "1.122.6",
+        "@tamagui/stacks": "1.122.6",
+        "@tamagui/use-controllable-state": "1.122.6",
+        "@tamagui/use-previous": "1.122.6"
       },
       "peerDependencies": {
         "react": "*"
       }
     },
     "node_modules/@tamagui/checkbox-headless": {
-      "version": "1.121.12",
-      "resolved": "https://registry.npmjs.org/@tamagui/checkbox-headless/-/checkbox-headless-1.121.12.tgz",
-      "integrity": "sha512-mWNSzuVqRNs8M3VkTUH1kezpQMaooxddKeLQiFUU7g6l/Oh6RdtYutqcsuVO+rm3Q4pf1XCokE3paSxvDFhR0g==",
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/checkbox-headless/-/checkbox-headless-1.122.6.tgz",
+      "integrity": "sha512-pDWS+5uD1wZ7IINe0KF1Wg8vTbhDGFgLutD2mj5Hm1uTXOZ6DfSRP1KGYH36U1/HD/WFX4ISJ5z8SSdYnT16Zg==",
       "dependencies": {
-        "@tamagui/compose-refs": "1.121.12",
-        "@tamagui/constants": "1.121.12",
-        "@tamagui/create-context": "1.121.12",
-        "@tamagui/focusable": "1.121.12",
-        "@tamagui/helpers": "1.121.12",
-        "@tamagui/label": "1.121.12",
-        "@tamagui/use-controllable-state": "1.121.12",
-        "@tamagui/use-previous": "1.121.12"
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/create-context": "1.122.6",
+        "@tamagui/focusable": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/label": "1.122.6",
+        "@tamagui/use-controllable-state": "1.122.6",
+        "@tamagui/use-previous": "1.122.6"
       },
       "peerDependencies": {
         "react": "*"
       }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/compose-refs": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.122.6.tgz",
+      "integrity": "sha512-s0+5w1+q/yozIE44D06GQBo/Mjsq6fYtEi09nWAQ9/h1CBweKl4S1Ph32iIhwj01GzeTwPSR8T8MMGoKoVri6w==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/constants": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.122.6.tgz",
+      "integrity": "sha512-jQ3gGlUT3m0L1RtIIo4pHIB0OvZemACD4mJTgwNe+fd+Ni9m2oxAmia/gWnLsb79zgdbpSZiwGBUSpgh2wL7+w==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/core": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.122.6.tgz",
+      "integrity": "sha512-fVPr8CYjWfHvHtMHleIApAOqzdWAk63pok403ndyMP/A4wPDnFGshpVlSxvO9d1rcpRSIneL69YwoiXvB673DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/react-native-media-driver": "1.122.6",
+        "@tamagui/react-native-use-pressable": "1.122.6",
+        "@tamagui/react-native-use-responder-events": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/web": "1.122.6"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/core/node_modules/@tamagui/web": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.122.6.tgz",
+      "integrity": "sha512-e+7qo44kHsHJUXU2C4OqiiGKCotuv23uyUvCdkd/Mx6Du11aY+F4wv/1dnNeCVPfWpnw9xDoLOneWm7vOPEBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/normalize-css-color": "1.122.6",
+        "@tamagui/timer": "1.122.6",
+        "@tamagui/types": "1.122.6",
+        "@tamagui/use-did-finish-ssr": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/use-force-update": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/create-context": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.122.6.tgz",
+      "integrity": "sha512-UYvoyF27oi0OzBb1Dac/QRlOv8+SUPvG0d6zomH5UVElDG0CBeClbrZqzIp/nyLJQhehhlL3iDKKeXbf+K3sLg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/focusable": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/focusable/-/focusable-1.122.6.tgz",
+      "integrity": "sha512-EJqD8lAZEqmf4RNs5rUUyNonvN8KL4xHYwp7WHgLJPLKPfqy8VTOIYv26qyTJksEQBF1bbp9BIxX1LWPuwaekg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/web": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/focusable/node_modules/@tamagui/web": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.122.6.tgz",
+      "integrity": "sha512-e+7qo44kHsHJUXU2C4OqiiGKCotuv23uyUvCdkd/Mx6Du11aY+F4wv/1dnNeCVPfWpnw9xDoLOneWm7vOPEBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/normalize-css-color": "1.122.6",
+        "@tamagui/timer": "1.122.6",
+        "@tamagui/types": "1.122.6",
+        "@tamagui/use-did-finish-ssr": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/use-force-update": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/get-button-sized": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-button-sized/-/get-button-sized-1.122.6.tgz",
+      "integrity": "sha512-VCG9VDpRmh05yh0gZtlnn+DZFUVhCdj93ziSF/nEThCOIjVwmBi1iXHqCgipiJ1S7sgtrrWSQsytgtJ8j2PMQA==",
+      "dependencies": {
+        "@tamagui/get-token": "1.122.6",
+        "@tamagui/web": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/get-button-sized/node_modules/@tamagui/web": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.122.6.tgz",
+      "integrity": "sha512-e+7qo44kHsHJUXU2C4OqiiGKCotuv23uyUvCdkd/Mx6Du11aY+F4wv/1dnNeCVPfWpnw9xDoLOneWm7vOPEBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/normalize-css-color": "1.122.6",
+        "@tamagui/timer": "1.122.6",
+        "@tamagui/types": "1.122.6",
+        "@tamagui/use-did-finish-ssr": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/use-force-update": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/get-font-sized": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-font-sized/-/get-font-sized-1.122.6.tgz",
+      "integrity": "sha512-RGIJuaRL2FbClBD9SKl7GO6vmjyHSYQPw7bYpLGIKV2tEAlwI92Z6JLYk6cp6g6+agIv1xDoNqpVF7wU+ZSobA==",
+      "dependencies": {
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/core": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/get-token": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-token/-/get-token-1.122.6.tgz",
+      "integrity": "sha512-om/XC9EptzJS3osoolCVCgufCHKxrz9zfHE9XJ1xfP+EBGH5bNQM7BowdPasMVwhbVAVqhZjzgaJp7B55wwXmw==",
+      "dependencies": {
+        "@tamagui/web": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/get-token/node_modules/@tamagui/web": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.122.6.tgz",
+      "integrity": "sha512-e+7qo44kHsHJUXU2C4OqiiGKCotuv23uyUvCdkd/Mx6Du11aY+F4wv/1dnNeCVPfWpnw9xDoLOneWm7vOPEBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/normalize-css-color": "1.122.6",
+        "@tamagui/timer": "1.122.6",
+        "@tamagui/types": "1.122.6",
+        "@tamagui/use-did-finish-ssr": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/use-force-update": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/helpers": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.122.6.tgz",
+      "integrity": "sha512-jsxKkJUR2Jd5NQTwtRzPJmtuLuEFp9o46n8b9QY1loRhI65uvfoM0XwmsAxwnlPRJLo2C1Otuc7ip43uf4HAgQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/simple-hash": "1.122.6"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/helpers-tamagui": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.122.6.tgz",
+      "integrity": "sha512-BT0fLH5r2ucIa3T9r+ORuRbC5XR/z3nGaMmGCfIblOniv6qoDtVAZyY3zaAbD97U+l+pi/hCZcZ1Go324J0+0w==",
+      "dependencies": {
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/web": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/helpers-tamagui/node_modules/@tamagui/web": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.122.6.tgz",
+      "integrity": "sha512-e+7qo44kHsHJUXU2C4OqiiGKCotuv23uyUvCdkd/Mx6Du11aY+F4wv/1dnNeCVPfWpnw9xDoLOneWm7vOPEBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/normalize-css-color": "1.122.6",
+        "@tamagui/timer": "1.122.6",
+        "@tamagui/types": "1.122.6",
+        "@tamagui/use-did-finish-ssr": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/use-force-update": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/label": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/label/-/label-1.122.6.tgz",
+      "integrity": "sha512-tOfFGGzQoJhDuJG4H9BcSBVFHxZ/OZd9iZVNuLBsd2mUfE0N470lx2tdP8KKgM6mXAWZkS52ItQVN4tB5fhnfA==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/create-context": "1.122.6",
+        "@tamagui/focusable": "1.122.6",
+        "@tamagui/get-button-sized": "1.122.6",
+        "@tamagui/get-font-sized": "1.122.6",
+        "@tamagui/text": "1.122.6",
+        "@tamagui/web": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/label/node_modules/@tamagui/web": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.122.6.tgz",
+      "integrity": "sha512-e+7qo44kHsHJUXU2C4OqiiGKCotuv23uyUvCdkd/Mx6Du11aY+F4wv/1dnNeCVPfWpnw9xDoLOneWm7vOPEBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/normalize-css-color": "1.122.6",
+        "@tamagui/timer": "1.122.6",
+        "@tamagui/types": "1.122.6",
+        "@tamagui/use-did-finish-ssr": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/use-force-update": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.122.6.tgz",
+      "integrity": "sha512-ZOZ+cteu96rlu4GJCYKZZkMIlb8iMIqWWfC30UCJ2TWoWMlwK2tsQtmGPphmmDxBklcEJDokw0E20qfUQpRBcA==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/react-native-media-driver": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-media-driver/-/react-native-media-driver-1.122.6.tgz",
+      "integrity": "sha512-fj9VcmyEdvS6fL2w+kF0oRtDG2yDdq8g05N6UAfOErxeSbFzjepTsGvMpeuGtqz/RXq4+Isf/AMQlBjI1cfJAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/web": "1.122.6"
+      },
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/react-native-media-driver/node_modules/@tamagui/web": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.122.6.tgz",
+      "integrity": "sha512-e+7qo44kHsHJUXU2C4OqiiGKCotuv23uyUvCdkd/Mx6Du11aY+F4wv/1dnNeCVPfWpnw9xDoLOneWm7vOPEBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/normalize-css-color": "1.122.6",
+        "@tamagui/timer": "1.122.6",
+        "@tamagui/types": "1.122.6",
+        "@tamagui/use-did-finish-ssr": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/use-force-update": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.122.6.tgz",
+      "integrity": "sha512-W9KjWJovPl9TsS607VJoFRrW+52t/yUDUnXexmggiewfw/Hi6+SXCRb1X5zKkwU/QeAvUVprnoOwuo9jzx0zZg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.122.6.tgz",
+      "integrity": "sha512-hGVE97TOT/NGXQ0rullIdbWH7C6SoTnckBnnWfyR4T0+eIPI3yjcQuB3grzIVTrgpIeFyCQGZX2MWpRELt9F3w==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/simple-hash": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.122.6.tgz",
+      "integrity": "sha512-iqM4bDQdgBGV+5Y1B8qE+qHqYmxLm/6GghinlSuyyR3hEFG5534VukWBv3abkpLwQa57VWF0YKX9DSJMtehPpQ=="
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/start-transition": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/start-transition/-/start-transition-1.122.6.tgz",
+      "integrity": "sha512-MwHPQSbbDyOYHoo73xuHRd9Vu5a37ooMfper3LGJY7dVjkq6SGcotgIsIhOGl6TENRfYbv2aVa4RUAVyQfTBtw==",
+      "license": "MIT"
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/text": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/text/-/text-1.122.6.tgz",
+      "integrity": "sha512-zwfhUkFO/9Rd13w25J/uaece2o/lvgAeNcSOuIWUejPqEw+RuOX2vJledfuUacFa4BSQODdrBpObJtgnbzdOuQ==",
+      "dependencies": {
+        "@tamagui/get-font-sized": "1.122.6",
+        "@tamagui/helpers-tamagui": "1.122.6",
+        "@tamagui/web": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/text/node_modules/@tamagui/web": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.122.6.tgz",
+      "integrity": "sha512-e+7qo44kHsHJUXU2C4OqiiGKCotuv23uyUvCdkd/Mx6Du11aY+F4wv/1dnNeCVPfWpnw9xDoLOneWm7vOPEBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/normalize-css-color": "1.122.6",
+        "@tamagui/timer": "1.122.6",
+        "@tamagui/types": "1.122.6",
+        "@tamagui/use-did-finish-ssr": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/use-force-update": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/timer": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.122.6.tgz",
+      "integrity": "sha512-91128V41xqQbBPH7VoS1OZuI80nSxqcFGmXbD0A5KkhTQogiARgoLzrPs4bhHaTueooOL5TUZBUcO3ScGo6Mxw=="
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/types": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.122.6.tgz",
+      "integrity": "sha512-sCP6NO/9M0sJ8bGZsNdtk4red7ADg1qklXld/ZpxmSYbTGmdHWPJTnrILTCNJwtVvUGtNoCJtUk3/6Pj57necw=="
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/use-controllable-state": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.122.6.tgz",
+      "integrity": "sha512-x8Wlf3ZHXJ7VsPvqMMii6nN/3nCt8YjJCuPiQuyJHihbZpHfCrKbvC3u+FK+IeHk4+0bjrpIg/zFv7Rk/jB7bw==",
+      "dependencies": {
+        "@tamagui/start-transition": "1.122.6",
+        "@tamagui/use-event": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.122.6.tgz",
+      "integrity": "sha512-efwj3aCop+ANPbUQvG/la69NjGJ047x8GM6oXg25DJ4REgEPBZm+cyBgd4dzWJH2u1No05QUjrL9K2CoiUph1Q==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/use-event": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.122.6.tgz",
+      "integrity": "sha512-TYs6VhRrswHtQpbL+8y43kUl5trBuSmvhsSs2lTfb2aiHwoM/Eheai9qf8+Lo7CX4sF95/UlZLiOWDHfdElSxw==",
+      "dependencies": {
+        "@tamagui/constants": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/use-force-update": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.122.6.tgz",
+      "integrity": "sha512-r+JnSBZZb21qywaKVrn/BM+BkJggtFW2ZrcCa6Wpz4O7zt8LLm0ELfwG0coVMdQ7gl2hxuJCk6PAaeIziVhSoA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox-headless/node_modules/@tamagui/use-previous": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-previous/-/use-previous-1.122.6.tgz",
+      "integrity": "sha512-dIR+leOl9DPXcAqndS9qeu7wQigmyn4ZDPnQ9B3UMa14rPlXOUWN2TdUQevJrIaXZ8bogIdpot4tO+YZc1f22A=="
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/compose-refs": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/compose-refs/-/compose-refs-1.122.6.tgz",
+      "integrity": "sha512-s0+5w1+q/yozIE44D06GQBo/Mjsq6fYtEi09nWAQ9/h1CBweKl4S1Ph32iIhwj01GzeTwPSR8T8MMGoKoVri6w==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/constants": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/constants/-/constants-1.122.6.tgz",
+      "integrity": "sha512-jQ3gGlUT3m0L1RtIIo4pHIB0OvZemACD4mJTgwNe+fd+Ni9m2oxAmia/gWnLsb79zgdbpSZiwGBUSpgh2wL7+w==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/core": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/core/-/core-1.122.6.tgz",
+      "integrity": "sha512-fVPr8CYjWfHvHtMHleIApAOqzdWAk63pok403ndyMP/A4wPDnFGshpVlSxvO9d1rcpRSIneL69YwoiXvB673DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/react-native-media-driver": "1.122.6",
+        "@tamagui/react-native-use-pressable": "1.122.6",
+        "@tamagui/react-native-use-responder-events": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/web": "1.122.6"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/core/node_modules/@tamagui/web": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.122.6.tgz",
+      "integrity": "sha512-e+7qo44kHsHJUXU2C4OqiiGKCotuv23uyUvCdkd/Mx6Du11aY+F4wv/1dnNeCVPfWpnw9xDoLOneWm7vOPEBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/normalize-css-color": "1.122.6",
+        "@tamagui/timer": "1.122.6",
+        "@tamagui/types": "1.122.6",
+        "@tamagui/use-did-finish-ssr": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/use-force-update": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/create-context": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/create-context/-/create-context-1.122.6.tgz",
+      "integrity": "sha512-UYvoyF27oi0OzBb1Dac/QRlOv8+SUPvG0d6zomH5UVElDG0CBeClbrZqzIp/nyLJQhehhlL3iDKKeXbf+K3sLg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/focusable": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/focusable/-/focusable-1.122.6.tgz",
+      "integrity": "sha512-EJqD8lAZEqmf4RNs5rUUyNonvN8KL4xHYwp7WHgLJPLKPfqy8VTOIYv26qyTJksEQBF1bbp9BIxX1LWPuwaekg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/web": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/focusable/node_modules/@tamagui/web": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.122.6.tgz",
+      "integrity": "sha512-e+7qo44kHsHJUXU2C4OqiiGKCotuv23uyUvCdkd/Mx6Du11aY+F4wv/1dnNeCVPfWpnw9xDoLOneWm7vOPEBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/normalize-css-color": "1.122.6",
+        "@tamagui/timer": "1.122.6",
+        "@tamagui/types": "1.122.6",
+        "@tamagui/use-did-finish-ssr": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/use-force-update": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/font-size": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/font-size/-/font-size-1.122.6.tgz",
+      "integrity": "sha512-lwMND9grQ5eI2K9Ow0RLADJDBD9Cl5iqyEtcaGXVZFe8O7Qk8QidFKiGY+5ebDIrbaMAE5zARPXRfePLGIpBCA==",
+      "dependencies": {
+        "@tamagui/core": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/get-button-sized": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-button-sized/-/get-button-sized-1.122.6.tgz",
+      "integrity": "sha512-VCG9VDpRmh05yh0gZtlnn+DZFUVhCdj93ziSF/nEThCOIjVwmBi1iXHqCgipiJ1S7sgtrrWSQsytgtJ8j2PMQA==",
+      "dependencies": {
+        "@tamagui/get-token": "1.122.6",
+        "@tamagui/web": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/get-button-sized/node_modules/@tamagui/web": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.122.6.tgz",
+      "integrity": "sha512-e+7qo44kHsHJUXU2C4OqiiGKCotuv23uyUvCdkd/Mx6Du11aY+F4wv/1dnNeCVPfWpnw9xDoLOneWm7vOPEBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/normalize-css-color": "1.122.6",
+        "@tamagui/timer": "1.122.6",
+        "@tamagui/types": "1.122.6",
+        "@tamagui/use-did-finish-ssr": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/use-force-update": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/get-font-sized": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-font-sized/-/get-font-sized-1.122.6.tgz",
+      "integrity": "sha512-RGIJuaRL2FbClBD9SKl7GO6vmjyHSYQPw7bYpLGIKV2tEAlwI92Z6JLYk6cp6g6+agIv1xDoNqpVF7wU+ZSobA==",
+      "dependencies": {
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/core": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/get-token": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/get-token/-/get-token-1.122.6.tgz",
+      "integrity": "sha512-om/XC9EptzJS3osoolCVCgufCHKxrz9zfHE9XJ1xfP+EBGH5bNQM7BowdPasMVwhbVAVqhZjzgaJp7B55wwXmw==",
+      "dependencies": {
+        "@tamagui/web": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/get-token/node_modules/@tamagui/web": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.122.6.tgz",
+      "integrity": "sha512-e+7qo44kHsHJUXU2C4OqiiGKCotuv23uyUvCdkd/Mx6Du11aY+F4wv/1dnNeCVPfWpnw9xDoLOneWm7vOPEBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/normalize-css-color": "1.122.6",
+        "@tamagui/timer": "1.122.6",
+        "@tamagui/types": "1.122.6",
+        "@tamagui/use-did-finish-ssr": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/use-force-update": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/helpers": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers/-/helpers-1.122.6.tgz",
+      "integrity": "sha512-jsxKkJUR2Jd5NQTwtRzPJmtuLuEFp9o46n8b9QY1loRhI65uvfoM0XwmsAxwnlPRJLo2C1Otuc7ip43uf4HAgQ==",
+      "dependencies": {
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/simple-hash": "1.122.6"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/helpers-tamagui": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/helpers-tamagui/-/helpers-tamagui-1.122.6.tgz",
+      "integrity": "sha512-BT0fLH5r2ucIa3T9r+ORuRbC5XR/z3nGaMmGCfIblOniv6qoDtVAZyY3zaAbD97U+l+pi/hCZcZ1Go324J0+0w==",
+      "dependencies": {
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/web": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/helpers-tamagui/node_modules/@tamagui/web": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.122.6.tgz",
+      "integrity": "sha512-e+7qo44kHsHJUXU2C4OqiiGKCotuv23uyUvCdkd/Mx6Du11aY+F4wv/1dnNeCVPfWpnw9xDoLOneWm7vOPEBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/normalize-css-color": "1.122.6",
+        "@tamagui/timer": "1.122.6",
+        "@tamagui/types": "1.122.6",
+        "@tamagui/use-did-finish-ssr": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/use-force-update": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/label": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/label/-/label-1.122.6.tgz",
+      "integrity": "sha512-tOfFGGzQoJhDuJG4H9BcSBVFHxZ/OZd9iZVNuLBsd2mUfE0N470lx2tdP8KKgM6mXAWZkS52ItQVN4tB5fhnfA==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/create-context": "1.122.6",
+        "@tamagui/focusable": "1.122.6",
+        "@tamagui/get-button-sized": "1.122.6",
+        "@tamagui/get-font-sized": "1.122.6",
+        "@tamagui/text": "1.122.6",
+        "@tamagui/web": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/label/node_modules/@tamagui/web": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.122.6.tgz",
+      "integrity": "sha512-e+7qo44kHsHJUXU2C4OqiiGKCotuv23uyUvCdkd/Mx6Du11aY+F4wv/1dnNeCVPfWpnw9xDoLOneWm7vOPEBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/normalize-css-color": "1.122.6",
+        "@tamagui/timer": "1.122.6",
+        "@tamagui/types": "1.122.6",
+        "@tamagui/use-did-finish-ssr": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/use-force-update": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/normalize-css-color": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/normalize-css-color/-/normalize-css-color-1.122.6.tgz",
+      "integrity": "sha512-ZOZ+cteu96rlu4GJCYKZZkMIlb8iMIqWWfC30UCJ2TWoWMlwK2tsQtmGPphmmDxBklcEJDokw0E20qfUQpRBcA==",
+      "dependencies": {
+        "@react-native/normalize-color": "^2.1.0"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/react-native-media-driver": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-media-driver/-/react-native-media-driver-1.122.6.tgz",
+      "integrity": "sha512-fj9VcmyEdvS6fL2w+kF0oRtDG2yDdq8g05N6UAfOErxeSbFzjepTsGvMpeuGtqz/RXq4+Isf/AMQlBjI1cfJAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/web": "1.122.6"
+      },
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/react-native-media-driver/node_modules/@tamagui/web": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.122.6.tgz",
+      "integrity": "sha512-e+7qo44kHsHJUXU2C4OqiiGKCotuv23uyUvCdkd/Mx6Du11aY+F4wv/1dnNeCVPfWpnw9xDoLOneWm7vOPEBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/normalize-css-color": "1.122.6",
+        "@tamagui/timer": "1.122.6",
+        "@tamagui/types": "1.122.6",
+        "@tamagui/use-did-finish-ssr": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/use-force-update": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/react-native-use-pressable": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-pressable/-/react-native-use-pressable-1.122.6.tgz",
+      "integrity": "sha512-W9KjWJovPl9TsS607VJoFRrW+52t/yUDUnXexmggiewfw/Hi6+SXCRb1X5zKkwU/QeAvUVprnoOwuo9jzx0zZg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/react-native-use-responder-events": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/react-native-use-responder-events/-/react-native-use-responder-events-1.122.6.tgz",
+      "integrity": "sha512-hGVE97TOT/NGXQ0rullIdbWH7C6SoTnckBnnWfyR4T0+eIPI3yjcQuB3grzIVTrgpIeFyCQGZX2MWpRELt9F3w==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/simple-hash": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/simple-hash/-/simple-hash-1.122.6.tgz",
+      "integrity": "sha512-iqM4bDQdgBGV+5Y1B8qE+qHqYmxLm/6GghinlSuyyR3hEFG5534VukWBv3abkpLwQa57VWF0YKX9DSJMtehPpQ=="
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/stacks": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/stacks/-/stacks-1.122.6.tgz",
+      "integrity": "sha512-UmYZf5je+fNcTr1yL+FD1T7BQzZ70XJdzo9lN/PJZgztGMrPtcPQWF3a/Fy2qp9dk2DFGO19gP00ddAsl+LjYg==",
+      "dependencies": {
+        "@tamagui/core": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/start-transition": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/start-transition/-/start-transition-1.122.6.tgz",
+      "integrity": "sha512-MwHPQSbbDyOYHoo73xuHRd9Vu5a37ooMfper3LGJY7dVjkq6SGcotgIsIhOGl6TENRfYbv2aVa4RUAVyQfTBtw==",
+      "license": "MIT"
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/text": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/text/-/text-1.122.6.tgz",
+      "integrity": "sha512-zwfhUkFO/9Rd13w25J/uaece2o/lvgAeNcSOuIWUejPqEw+RuOX2vJledfuUacFa4BSQODdrBpObJtgnbzdOuQ==",
+      "dependencies": {
+        "@tamagui/get-font-sized": "1.122.6",
+        "@tamagui/helpers-tamagui": "1.122.6",
+        "@tamagui/web": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/text/node_modules/@tamagui/web": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/web/-/web-1.122.6.tgz",
+      "integrity": "sha512-e+7qo44kHsHJUXU2C4OqiiGKCotuv23uyUvCdkd/Mx6Du11aY+F4wv/1dnNeCVPfWpnw9xDoLOneWm7vOPEBgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.122.6",
+        "@tamagui/constants": "1.122.6",
+        "@tamagui/helpers": "1.122.6",
+        "@tamagui/normalize-css-color": "1.122.6",
+        "@tamagui/timer": "1.122.6",
+        "@tamagui/types": "1.122.6",
+        "@tamagui/use-did-finish-ssr": "1.122.6",
+        "@tamagui/use-event": "1.122.6",
+        "@tamagui/use-force-update": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/timer": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/timer/-/timer-1.122.6.tgz",
+      "integrity": "sha512-91128V41xqQbBPH7VoS1OZuI80nSxqcFGmXbD0A5KkhTQogiARgoLzrPs4bhHaTueooOL5TUZBUcO3ScGo6Mxw=="
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/types": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/types/-/types-1.122.6.tgz",
+      "integrity": "sha512-sCP6NO/9M0sJ8bGZsNdtk4red7ADg1qklXld/ZpxmSYbTGmdHWPJTnrILTCNJwtVvUGtNoCJtUk3/6Pj57necw=="
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/use-controllable-state": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-controllable-state/-/use-controllable-state-1.122.6.tgz",
+      "integrity": "sha512-x8Wlf3ZHXJ7VsPvqMMii6nN/3nCt8YjJCuPiQuyJHihbZpHfCrKbvC3u+FK+IeHk4+0bjrpIg/zFv7Rk/jB7bw==",
+      "dependencies": {
+        "@tamagui/start-transition": "1.122.6",
+        "@tamagui/use-event": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/use-did-finish-ssr": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-did-finish-ssr/-/use-did-finish-ssr-1.122.6.tgz",
+      "integrity": "sha512-efwj3aCop+ANPbUQvG/la69NjGJ047x8GM6oXg25DJ4REgEPBZm+cyBgd4dzWJH2u1No05QUjrL9K2CoiUph1Q==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/use-event": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-event/-/use-event-1.122.6.tgz",
+      "integrity": "sha512-TYs6VhRrswHtQpbL+8y43kUl5trBuSmvhsSs2lTfb2aiHwoM/Eheai9qf8+Lo7CX4sF95/UlZLiOWDHfdElSxw==",
+      "dependencies": {
+        "@tamagui/constants": "1.122.6"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/use-force-update": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-force-update/-/use-force-update-1.122.6.tgz",
+      "integrity": "sha512-r+JnSBZZb21qywaKVrn/BM+BkJggtFW2ZrcCa6Wpz4O7zt8LLm0ELfwG0coVMdQ7gl2hxuJCk6PAaeIziVhSoA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@tamagui/checkbox/node_modules/@tamagui/use-previous": {
+      "version": "1.122.6",
+      "resolved": "https://registry.npmjs.org/@tamagui/use-previous/-/use-previous-1.122.6.tgz",
+      "integrity": "sha512-dIR+leOl9DPXcAqndS9qeu7wQigmyn4ZDPnQ9B3UMa14rPlXOUWN2TdUQevJrIaXZ8bogIdpot4tO+YZc1f22A=="
     },
     "node_modules/@tamagui/collapsible": {
       "version": "1.121.12",
@@ -16758,6 +17595,48 @@
         "@tamagui/use-force-update": "1.121.12",
         "@tamagui/use-window-dimensions": "1.121.12",
         "@tamagui/visually-hidden": "1.121.12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/checkbox": {
+      "version": "1.121.12",
+      "resolved": "https://registry.npmjs.org/@tamagui/checkbox/-/checkbox-1.121.12.tgz",
+      "integrity": "sha512-cySEIQ399GApeDP408+rXWuHEgiKshLLgyqWJaFibbGSzgnAAPPa2RSavA00B1kSgXwEHupxVgkhkBQ4ph/P4Q==",
+      "dependencies": {
+        "@tamagui/checkbox-headless": "1.121.12",
+        "@tamagui/compose-refs": "1.121.12",
+        "@tamagui/constants": "1.121.12",
+        "@tamagui/core": "1.121.12",
+        "@tamagui/create-context": "1.121.12",
+        "@tamagui/focusable": "1.121.12",
+        "@tamagui/font-size": "1.121.12",
+        "@tamagui/get-token": "1.121.12",
+        "@tamagui/helpers": "1.121.12",
+        "@tamagui/helpers-tamagui": "1.121.12",
+        "@tamagui/label": "1.121.12",
+        "@tamagui/stacks": "1.121.12",
+        "@tamagui/use-controllable-state": "1.121.12",
+        "@tamagui/use-previous": "1.121.12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/tamagui/node_modules/@tamagui/checkbox-headless": {
+      "version": "1.121.12",
+      "resolved": "https://registry.npmjs.org/@tamagui/checkbox-headless/-/checkbox-headless-1.121.12.tgz",
+      "integrity": "sha512-mWNSzuVqRNs8M3VkTUH1kezpQMaooxddKeLQiFUU7g6l/Oh6RdtYutqcsuVO+rm3Q4pf1XCokE3paSxvDFhR0g==",
+      "dependencies": {
+        "@tamagui/compose-refs": "1.121.12",
+        "@tamagui/constants": "1.121.12",
+        "@tamagui/create-context": "1.121.12",
+        "@tamagui/focusable": "1.121.12",
+        "@tamagui/helpers": "1.121.12",
+        "@tamagui/label": "1.121.12",
+        "@tamagui/use-controllable-state": "1.121.12",
+        "@tamagui/use-previous": "1.121.12"
       },
       "peerDependencies": {
         "react": "*"

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -21,6 +21,7 @@
     "@react-native-picker/picker": "2.9.0",
     "@react-navigation/native": "^7.0.3",
     "@react-navigation/stack": "^7.0.5",
+    "@tamagui/checkbox": "^1.122.6",
     "@tamagui/config": "^1.117.1",
     "@tamagui/core": "^1.117.1",
     "@tamagui/font-inter": "^1.117.1",


### PR DESCRIPTION
changes:
- onboarding page + states (viewable after users register for an account which gets recorded into firestore)
- finishing onboarding information redirects to overview page with limited PII (i.e. display "welcome ${full name}")
- add in new pkg - tamagui/checkbox and new svg (checkbox)
- update routes

comments:
thoughts on removing the back arrow navigation in onboarding page? currently i have it implemented as what we have on figma. i.e. users can click back arrow to return to the register page (which will auto populate the field with the previously used email they registered with).
1) this can put the user registration process in a faulty state where they will not be able to input their information if they choose to exit midway during the onboarding process
2) should we add the user data to firestore after this entire onboarding process is finished? this basically means users will not be able to create their account until all the information is inputted. the only problem i see with this one though is we might not be able to get firebase validation for email/password until the end (could also be tacky if we proceed using login via popups, redirects, oauth, etc...)
3) combine all register/onboarding page into one page - downside is that it may be crammed but easier to manage for us lol
4) defer onboarding process to allow users to edit their info when they're logged in (i.e. by editing profile or smth) (i.e. "Continue later")

my vote is to just remove the option to go back when we're in the onboarding page. i.e. users must input data to proceed with the app.
![image](https://github.com/user-attachments/assets/6f6ab129-b69b-4eaa-815b-a5c80c1e2de3)

to-do:
- add in required fields (pretty simple fix, feel lazy so could probs go into a validation/cleanup PR)
- replace text inputs with dropdowns/calendar selection (probs separate PR too)